### PR TITLE
[Feature] #15 - 다문화 지원센터 데이터 전달

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
 	implementation("org.springframework.boot:spring-boot-starter-mail:3.1.5")
+	implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
 }
 
 kotlin {

--- a/src/main/kotlin/hs/kr/gbsw/doumi/map/controller/MapController.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/map/controller/MapController.kt
@@ -1,0 +1,29 @@
+package hs.kr.gbsw.doumi.map.controller
+
+import hs.kr.gbsw.doumi.map.dto.MapRequestDto
+import hs.kr.gbsw.doumi.map.dto.MapResponseDto
+import hs.kr.gbsw.doumi.map.service.MapService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/map")
+@RestController
+class MapController(
+    val mapService: MapService,
+) {
+
+    @GetMapping
+    fun map(
+        @RequestParam ctpvNm: String,
+        @RequestParam sggNm: String,
+    ): ResponseEntity<MapResponseDto> {
+        val dto = MapRequestDto(ctpvNm, sggNm)
+        val response = mapService.getCenterList(dto)
+        return ResponseEntity(response, HttpStatus.OK)
+    }
+
+}

--- a/src/main/kotlin/hs/kr/gbsw/doumi/map/dto/MapDto.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/map/dto/MapDto.kt
@@ -1,0 +1,35 @@
+package hs.kr.gbsw.doumi.map.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+data class MapRequestDto(
+    val ctpvNm: String?,
+    val sggNm: String?,
+)
+
+data class MapResponseDto(
+    val items: List<CenterItem>
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CenterItem(
+    val cnterNm: String,
+    val cnterChNm: String,
+    val operMbyCn: String,
+    val operModeCn: String,
+    val ctpvNm: String,
+    val sggNm: String,
+    val roadNmAddr: String,
+    val lotnoAddr: String,
+    val hmpgAddr: String,
+    val rprsTelno: String,
+    val dscsnTelno: String,
+    val fxno: String,
+    val emlAddr: String,
+    val operHrCn: String,
+    val empCnt: Int,
+    val pvsnLngNm: String,
+    val crtrYmd: String,
+    val expsrYn: String,
+    val rmrkCn: String?
+)

--- a/src/main/kotlin/hs/kr/gbsw/doumi/map/service/MapService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/map/service/MapService.kt
@@ -1,0 +1,62 @@
+package hs.kr.gbsw.doumi.map.service
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import hs.kr.gbsw.doumi.map.dto.CenterItem
+import hs.kr.gbsw.doumi.map.dto.MapRequestDto
+import hs.kr.gbsw.doumi.map.dto.MapResponseDto
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.io.BufferedReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+
+@Service
+class MapService {
+
+    @Value("\${map.url}")
+    lateinit var mtpcltFamSpcn: String
+
+    @Value("\${map.encode}")
+    lateinit var key: String
+
+    fun getCenterList(dto: MapRequestDto): MapResponseDto {
+
+        val ctpvNm = dto.ctpvNm?.let {
+            "&ctpvNm=" + URLEncoder.encode(it, "UTF-8")
+        } ?: ""
+        val sggNm = dto.sggNm?.let {
+            "&sggNm=" + URLEncoder.encode(it, "UTF-8")
+        } ?: ""
+
+        val urlStr = "$mtpcltFamSpcn?serviceKey=$key&pageNo=1&numOfRows=100&type=json$sggNm$ctpvNm"
+        val url = URL(urlStr)
+        val conn = url.openConnection() as HttpURLConnection
+
+        conn.requestMethod = "GET"
+        conn.setRequestProperty("Accept", "application/json")
+        conn.connectTimeout = 5000
+        conn.readTimeout = 5000
+
+        val responseCode = conn.responseCode
+        val response = if (responseCode == 200) {
+            conn.inputStream.bufferedReader().use(BufferedReader::readText)
+        } else {
+            conn.errorStream?.bufferedReader()?.use(BufferedReader::readText) ?: ""
+        }
+
+        val objectMapper = jacksonObjectMapper()
+        val root = objectMapper.readTree(response)
+
+        val itemsNode = root.path("response").path("body").path("items").path("item")
+        val centerList = when {
+            itemsNode.isArray -> objectMapper.convertValue(itemsNode, object : TypeReference<List<CenterItem>>() {})
+            itemsNode.isObject -> listOf(objectMapper.convertValue(itemsNode, CenterItem::class.java))
+            else -> emptyList()
+        }
+
+        return MapResponseDto(centerList)
+
+    }
+}


### PR DESCRIPTION
## 작업 내용
- [x] 요청 시 다문화 지원센터의 데이터를 전달하도록 구현하였음

## 변경 사항 상세
### POST /api/map 구현.
#### 시도명(ctpvNm), 시군구명(sggNm)을 파라미터로 전달
- 해당 도(혹은 시)의 시군구에 존재하는 다문화 지원센터의 데이터(센터명, 센터장명, 주체, 운형 형태, 시도명, 시군구명, 도로명주소, 지번주소, 홈페이지, 대표 전화번호, 상담 전화번호, 팩스, 이메일, 운영 시간, 직원 수, 제공 언어, 데이터 기준일, 노출 여부, 비고)를 반환함.

## 주의사항
- 위도와 경도 대신 주소 반환
 
## 관련 이슈
- **#15**