### PR TITLE
[Feature] #17 - Google OAuth 로그인

### DIFF
--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/JwtTokenProvider.kt
@@ -1,16 +1,12 @@
 package hs.kr.gbsw.doumi.auth.jwt
 
-import hs.kr.gbsw.doumi.auth.jwt.dto.CustomUser
 import hs.kr.gbsw.doumi.auth.user.model.Users
 import io.jsonwebtoken.*
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.security.core.Authentication
-import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
-import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.stereotype.Component
 import java.util.Date
 import javax.crypto.SecretKey
@@ -30,63 +26,44 @@ class JwtTokenProvider {
     private val accessKey by lazy { Keys.hmacShaKeyFor(Decoders.BASE64.decode(access)) }
     private val refreshKey by lazy { Keys.hmacShaKeyFor(Decoders.BASE64.decode(refresh)) }
 
-    fun createToken(authentication: Authentication): TokenInfo {
-        val auth = authentication.authorities
-            .joinToString(",", transform = GrantedAuthority::getAuthority)
-
+    fun createToken(user: Users): TokenInfo {
         val now = Date()
         val accessExpiration = Date(now.time + ACCESS_EXPIRATION_MILLISECONDS)
         val refreshExpiration = Date(now.time + REFRESH_EXPIRATION_MILLISECONDS)
 
-        val user = authentication.principal as CustomUser
-
         val accessToken = Jwts.builder()
-            .subject(user.username)
+            .subject(user.email)
             .issuedAt(now)
             .expiration(accessExpiration)
-            .claim("auth", auth)
-            .claim("userId", user.userId)
+            .claim("userId", user.id)
+            .claim("email", user.email)
+            .claim("auth", user.provider)
             .signWith(accessKey, Jwts.SIG.HS256)
             .compact()
 
         val refreshToken = Jwts.builder()
-            .subject(user.username)
+            .subject(user.email)
             .issuedAt(now)
             .expiration(refreshExpiration)
-            .claim("auth", auth)
-            .claim("userId", user.userId)
+            .claim("userId", user.id)
+            .claim("email", user.email)
             .signWith(refreshKey, Jwts.SIG.HS256)
             .compact()
 
         return TokenInfo("Bearer", accessToken, refreshToken)
     }
 
-    fun getAuthentication(token: String): Authentication {
-        val claims: Claims = getClaims(token, accessKey)
-
-        val auth = claims["auth"] ?: throw RuntimeException("잘못된 토큰입니다.")
-        val userId = claims["userId"] ?: throw RuntimeException("잘못된 토큰입니다.")
-
-        val authorities: Collection<GrantedAuthority> =
-            (auth as String).split(",")
-                .map { SimpleGrantedAuthority(it) }
-
-        val principal: UserDetails = CustomUser(userId.toString().toLong(), claims.subject, "", authorities)
-
-        return UsernamePasswordAuthenticationToken(principal, "", authorities)
-    }
-
-    fun validateToken(token: String): Boolean {
+    fun validateToken(accessToken: String): Boolean {
         try {
-            getClaims(token, accessKey)
+            getClaims(accessToken, accessKey)
             return true
         } catch (e: Exception) {
             when (e) {
-                is SecurityException -> {}          // 유효하지 않은 토큰
-                is MalformedJwtException -> {}      // 유효하지 않은 토큰
-                is ExpiredJwtException -> {}        // 만료된 토큰
-                is UnsupportedJwtException -> {}    // 지원되지 않는 토큰
-                is IllegalArgumentException -> {}   // claims 문자열 비어있음
+                is SecurityException -> {}
+                is MalformedJwtException -> {}
+                is ExpiredJwtException -> {}
+                is UnsupportedJwtException -> {}
+                is IllegalArgumentException -> {}
                 else -> {}
             }
             println(e.message)
@@ -94,17 +71,17 @@ class JwtTokenProvider {
         return false
     }
 
-    fun validateRefreshToken(token: String): Boolean {
+    fun validateRefreshToken(accessToken: String): Boolean {
         try {
-            getClaims(token, refreshKey)
+            getClaims(accessToken, refreshKey)
             return true
         } catch (e: Exception) {
             when (e) {
-                is SecurityException -> {}          // 유효하지 않은 토큰
-                is MalformedJwtException -> {}      // 유효하지 않은 토큰
-                is ExpiredJwtException -> {}        // 만료된 토큰
-                is UnsupportedJwtException -> {}    // 지원되지 않는 토큰
-                is IllegalArgumentException -> {}   // claims 문자열 비어있음
+                is SecurityException -> {}
+                is MalformedJwtException -> {}
+                is ExpiredJwtException -> {}
+                is UnsupportedJwtException -> {}
+                is IllegalArgumentException -> {}
                 else -> {}
             }
             println(e.message)
@@ -115,19 +92,20 @@ class JwtTokenProvider {
     fun recreationAccessToken(refreshToken: String): String? {
         try {
             val claims = getClaims(refreshToken, refreshKey)
-            val username = claims.subject
+            val email = claims.subject
+            val userId = claims["userId"] as Long
             val auth = claims["auth"] as String
-            val userId = claims["userId"] as String
 
             val now = Date()
             val accessExpiration = Date(now.time + ACCESS_EXPIRATION_MILLISECONDS)
 
             return Jwts.builder()
-                .subject(username)
+                .subject(email)
                 .issuedAt(now)
                 .expiration(accessExpiration)
-                .claim("auth", auth)
                 .claim("userId", userId)
+                .claim("email", email)
+                .claim("auth", auth)
                 .signWith(accessKey, Jwts.SIG.HS256)
                 .compact()
         } catch (e: Exception) {
@@ -136,11 +114,21 @@ class JwtTokenProvider {
         }
     }
 
-    private fun getClaims(token: String, key: SecretKey): Claims =
+    fun getAuthentication(newAccessToken: String): UsernamePasswordAuthenticationToken? {
+        val claims = getClaims(newAccessToken, accessKey)
+        val email = claims.subject
+        val auth = claims["auth"] as String
+        val authorities = auth.split(",").map { SimpleGrantedAuthority(it.trim()) }
+        val principal = org.springframework.security.core.userdetails.User(email, "", authorities)
+        return UsernamePasswordAuthenticationToken(principal, "", authorities)
+    }
+
+
+    fun getClaims(accessToken: String, key: SecretKey): Claims =
         Jwts.parser()
             .verifyWith(key)
             .build()
-            .parseSignedClaims(token)
+            .parseSignedClaims(accessToken)
             .payload
 
 }

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/service/CustomUserDetailsService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/service/CustomUserDetailsService.kt
@@ -3,30 +3,36 @@ package hs.kr.gbsw.doumi.auth.jwt.service
 import hs.kr.gbsw.doumi.auth.jwt.dto.CustomUser
 import hs.kr.gbsw.doumi.auth.user.model.Users
 import hs.kr.gbsw.doumi.auth.user.repository.UserRepository
-import jakarta.persistence.EnumType
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.core.userdetails.UsernameNotFoundException
-import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 
 @Service
 class CustomUserDetailsService(
     private val userRepository: UserRepository,
-): UserDetailsService {
+) : UserDetailsService {
 
     override fun loadUserByUsername(username: String): UserDetails =
         userRepository.findByEmail(username)?.let {
             createUserDetails(it)
         } ?: throw UsernameNotFoundException("해당 유저는 존재하지 않습니다.")
 
-    private fun createUserDetails(user: Users): UserDetails =
-        CustomUser(
+    private fun createUserDetails(user: Users): UserDetails {
+        val authorities = mutableListOf<SimpleGrantedAuthority>()
+
+        // 사용자 권한을 설정. 예를 들어 OAuth 사용자의 경우 적절한 권한 부여.
+        authorities.add(SimpleGrantedAuthority("ROLE_USER"))
+        if (user.provider != null) {
+            authorities.add(SimpleGrantedAuthority("ROLE_OAUTH"))
+        }
+
+        return CustomUser(
             user.id!!,
             user.email,
-            user.password,
-            listOf(SimpleGrantedAuthority("USER"))
+            user.password?: "",
+            authorities
         )
-
+    }
 }

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/service/CustomUserDetailsService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/service/CustomUserDetailsService.kt
@@ -12,27 +12,19 @@ import org.springframework.stereotype.Service
 @Service
 class CustomUserDetailsService(
     private val userRepository: UserRepository,
-) : UserDetailsService {
+): UserDetailsService {
 
     override fun loadUserByUsername(username: String): UserDetails =
         userRepository.findByEmail(username)?.let {
             createUserDetails(it)
         } ?: throw UsernameNotFoundException("해당 유저는 존재하지 않습니다.")
 
-    private fun createUserDetails(user: Users): UserDetails {
-        val authorities = mutableListOf<SimpleGrantedAuthority>()
-
-        // 사용자 권한을 설정. 예를 들어 OAuth 사용자의 경우 적절한 권한 부여.
-        authorities.add(SimpleGrantedAuthority("ROLE_USER"))
-        if (user.provider != null) {
-            authorities.add(SimpleGrantedAuthority("ROLE_OAUTH"))
-        }
-
-        return CustomUser(
+    private fun createUserDetails(user: Users): UserDetails =
+        CustomUser(
             user.id!!,
             user.email,
-            user.password?: "",
-            authorities
+            user.password ?: "",
+            listOf(SimpleGrantedAuthority("USER"))
         )
-    }
+
 }

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/oauth/controller/OAuthController.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/oauth/controller/OAuthController.kt
@@ -1,0 +1,29 @@
+package hs.kr.gbsw.doumi.auth.oauth.controller
+
+import hs.kr.gbsw.doumi.auth.oauth.service.GoogleOAuthService
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/login/oauth2")
+class OAuthController(
+    private val googleOAuthService: GoogleOAuthService
+) {
+
+    @GetMapping("/google")
+    fun googleOAuth(response: HttpServletResponse) {
+        val loginUrl = googleOAuthService.getGoogleLoginUrl()
+
+        response.sendRedirect(loginUrl)
+    }
+
+    @GetMapping("/code/google")
+    fun handleGoogleCallback(@RequestParam("code") authCode: String): ResponseEntity<ResponseEntity<Map<String, Any>>> {
+        val googleToken = googleOAuthService.exchangeAuthCodeForTokens(authCode)
+        val response = googleOAuthService.handleOAuthUser(googleToken)
+
+        return ResponseEntity.ok(response)
+    }
+
+}

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/oauth/service/GoogleOAuthService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/oauth/service/GoogleOAuthService.kt
@@ -1,0 +1,125 @@
+package hs.kr.gbsw.doumi.auth.oauth.service
+
+import hs.kr.gbsw.doumi.auth.jwt.JwtTokenProvider
+import hs.kr.gbsw.doumi.auth.user.model.Users
+import hs.kr.gbsw.doumi.auth.user.repository.UserRepository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.*
+import org.springframework.stereotype.Service
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestTemplate
+import java.time.LocalDateTime
+
+@Service
+class GoogleOAuthService(
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val userRepository: UserRepository,
+) {
+
+    @Value("\${spring.security.oauth2.client.registration.google.client-id}")
+    lateinit var clientId: String
+
+    @Value("\${spring.security.oauth2.client.registration.google.client-secret}")
+    lateinit var clientSecret: String
+
+    @Value("\${spring.security.oauth2.client.registration.google.redirect-uri}")
+    lateinit var redirectUri: String
+
+    fun getGoogleLoginUrl(): String {
+        return "https://accounts.google.com/o/oauth2/v2/auth" +
+                "?client_id=$clientId" +
+                "&redirect_uri=$redirectUri" +
+                "&response_type=code" +
+                "&scope=email profile"
+    }
+
+    fun exchangeAuthCodeForTokens(authCode: String): Map<String, Any> {
+        val tokenUrl = "https://oauth2.googleapis.com/token"
+
+        val requestBody = LinkedMultiValueMap<String, String>().apply {
+            add("code", authCode)
+            add("client_id", clientId)
+            add("client_secret", clientSecret)
+            add("redirect_uri", redirectUri)
+            add("grant_type", "authorization_code")
+        }
+
+        val restTemplate = RestTemplate()
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_FORM_URLENCODED
+        }
+        val entity = HttpEntity(requestBody, headers)
+
+        return try {
+            val response = restTemplate.postForEntity(tokenUrl, entity, Map::class.java)
+
+            if (response.statusCode == HttpStatus.OK) {
+                @Suppress("UNCHECKED_CAST")
+                response.body as? Map<String, Any>
+                    ?: throw RuntimeException("응답 형식이 올바르지 않습니다.")
+            } else {
+                throw RuntimeException("Google 토큰 요청 실패: ${response.statusCode}")
+            }
+        } catch (ex: Exception) {
+            throw RuntimeException("Google 인증 코드를 처리하는 중 오류 발생: ${ex.message}")
+        }
+    }
+
+
+    fun handleOAuthUser(token: Map<String, Any>): ResponseEntity<Map<String, Any>> {
+        val accessToken = token["access_token"] as String
+
+        val userInfo = fetchGoogleUserInfo(accessToken)
+
+        val email = userInfo["email"] as String
+        val name = userInfo["given_name"] as String
+        val providerId = userInfo["sub"] as String
+        val provider = "google"
+
+        val user = userRepository.findByEmail(email)
+            ?: userRepository.save(
+                Users(
+                    email = email,
+                    name = name,
+                    password = null,
+                    country = null,
+                    createdAt = LocalDateTime.now(),
+                    provider = provider,
+                    providerId = providerId
+                )
+            )
+
+        val tokenInfo = jwtTokenProvider.createToken(user)
+
+        return ResponseEntity(
+            mapOf(
+                "accessToken" to tokenInfo.accessToken,
+                "refreshToken" to tokenInfo.refreshToken,
+                "newUser" to (user.country == null)
+            ),
+            HttpStatus.OK
+        )
+    }
+
+    private fun fetchGoogleUserInfo(accessToken: String): Map<String, Any> {
+        val userInfoUrl = "https://www.googleapis.com/oauth2/v3/userinfo"
+        val headers = HttpHeaders().apply {
+            set("Authorization", "Bearer $accessToken")
+        }
+        val entity = HttpEntity<String>(headers)
+        val restTemplate = RestTemplate()
+        val response = restTemplate.exchange(
+            userInfoUrl,
+            HttpMethod.GET,
+            entity,
+            Map::class.java
+        )
+        if (response.statusCode != HttpStatus.OK) {
+            throw RuntimeException("Failed to fetch user info: ${response.statusCode}")
+        }
+        @Suppress("UNCHECKED_CAST")
+        return response.body as Map<String, Any>
+    }
+
+
+}

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/oauth/service/GoogleOAuthService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/oauth/service/GoogleOAuthService.kt
@@ -58,10 +58,10 @@ class GoogleOAuthService(
                 response.body as? Map<String, Any>
                     ?: throw RuntimeException("응답 형식이 올바르지 않습니다.")
             } else {
-                throw RuntimeException("Google 토큰 요청 실패: ${response.statusCode}")
+                throw RuntimeException("Google 토큰 요청 실패")
             }
         } catch (ex: Exception) {
-            throw RuntimeException("Google 인증 코드를 처리하는 중 오류 발생: ${ex.message}")
+            throw RuntimeException("Google 인증 코드를 처리하는 중 오류 발생")
         }
     }
 

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/oauth/service/GoogleOAuthService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/oauth/service/GoogleOAuthService.kt
@@ -114,9 +114,7 @@ class GoogleOAuthService(
             entity,
             Map::class.java
         )
-        if (response.statusCode != HttpStatus.OK) {
-            throw RuntimeException("Failed to fetch user info: ${response.statusCode}")
-        }
+
         @Suppress("UNCHECKED_CAST")
         return response.body as Map<String, Any>
     }

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/controller/UserController.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/controller/UserController.kt
@@ -1,7 +1,7 @@
 package hs.kr.gbsw.doumi.auth.user.controller
 
-import hs.kr.gbsw.doumi.auth.jwt.TokenInfo
 import hs.kr.gbsw.doumi.auth.jwt.dto.CustomUser
+import hs.kr.gbsw.doumi.auth.user.dto.CountryDto
 import hs.kr.gbsw.doumi.auth.user.dto.UserInfoResponse
 import hs.kr.gbsw.doumi.auth.user.dto.UserLoginRequest
 import hs.kr.gbsw.doumi.auth.user.dto.UserSignupRequest
@@ -11,11 +11,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RequestMapping("/api/users")
 @RestController
@@ -29,9 +25,8 @@ class UserController(
     }
 
     @PostMapping("/login")
-    fun login(@RequestBody @Valid dto: UserLoginRequest): ResponseEntity<TokenInfo> {
-        val tokenInfo = userService.login(dto)
-        return ResponseEntity(tokenInfo, HttpStatus.OK)
+    fun login(@RequestBody @Valid dto: UserLoginRequest): ResponseEntity<Map<String, String>> {
+        return userService.login(dto)
     }
 
     @GetMapping("/info")
@@ -39,6 +34,16 @@ class UserController(
         val email = (SecurityContextHolder.getContext().authentication.principal as CustomUser).username
         val user = userService.userInfo(email)
         return ResponseEntity(user, HttpStatus.OK)
+    }
+
+    @PostMapping("/update-country")
+    fun updateCountry(
+        @RequestHeader("Authorization") authorizationHeader: String,
+        @RequestBody countryDto: CountryDto
+    ): ResponseEntity<ResponseEntity<String>> {
+        val accessToken = authorizationHeader.substringAfter("Bearer ")
+
+        return ResponseEntity.ok(userService.updateCountry(accessToken, countryDto))
     }
 
 }

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/dto/CountryDto.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/dto/CountryDto.kt
@@ -1,0 +1,8 @@
+package hs.kr.gbsw.doumi.auth.user.dto
+
+import lombok.Setter
+
+@Setter
+data class CountryDto (
+    var contry: Int
+)

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/dto/UserDto.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/dto/UserDto.kt
@@ -34,7 +34,7 @@ data class UserSignupRequest(
             name = name,
             password = password,
             country = country,
-            provider = provider,
+            provider = provider ?: "default",
             providerId = providerId,
         )
 }

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/model/Users.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/model/Users.kt
@@ -23,7 +23,7 @@ class Users(
     @Column(nullable = true)
     var password: String?,
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     var country: Int?,
 
     @CreationTimestamp

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/service/UserService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/service/UserService.kt
@@ -2,15 +2,16 @@ package hs.kr.gbsw.doumi.auth.user.service
 
 import hs.kr.gbsw.doumi.auth.email.service.EmailService
 import hs.kr.gbsw.doumi.auth.jwt.JwtTokenProvider
-import hs.kr.gbsw.doumi.auth.jwt.TokenInfo
+import hs.kr.gbsw.doumi.auth.user.dto.CountryDto
 import hs.kr.gbsw.doumi.auth.user.dto.UserInfoResponse
 import hs.kr.gbsw.doumi.auth.user.dto.UserLoginRequest
 import hs.kr.gbsw.doumi.auth.user.dto.UserSignupRequest
 import hs.kr.gbsw.doumi.auth.user.repository.UserRepository
+import io.jsonwebtoken.io.Decoders
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 
@@ -18,10 +19,13 @@ import org.springframework.stereotype.Service
 class UserService(
     private val userRepository: UserRepository,
     private val passwordEncoder: PasswordEncoder,
-    private val authenticationManagerBuilder: AuthenticationManagerBuilder,
     private val jwtTokenProvider: JwtTokenProvider,
     private val emailService: EmailService
 ) {
+    @Value("\${jwt.access_secret}")
+    lateinit var access: String
+
+    private val accessKey by lazy { Keys.hmacShaKeyFor(Decoders.BASE64.decode(access)) }
 
     fun signup(dto: UserSignupRequest): ResponseEntity<String> {
         val verified = emailService.validateEmailCode(dto.email, dto.vernum)
@@ -32,20 +36,33 @@ class UserService(
         var user = userRepository.findByEmail(dto.email)
         if (user != null) {
             return ResponseEntity.status(400).body("이미 존재하는 이메일 입니다.")
-
         }
-
         user = dto.toEntity(dto.name, passwordEncoder.encode(dto.password))
         userRepository.save(user)
 
         return ResponseEntity.status(HttpStatus.OK).body("회원가입이 완료되었습니다.")
     }
 
-    fun login(dto: UserLoginRequest): TokenInfo {
-        val authenticationToken = UsernamePasswordAuthenticationToken(dto.email, dto.password)
-        val authentication = authenticationManagerBuilder.`object`.authenticate(authenticationToken)
+    fun login(dto: UserLoginRequest): ResponseEntity<Map<String, String>> {
+        val user = userRepository.findByEmail(dto.email)
+            ?: return ResponseEntity.status(404).body(
+                mapOf("message" to "존재하지 않는 이메일입니다.")
+            )
 
-        return jwtTokenProvider.createToken(authentication)
+        if (!passwordEncoder.matches(dto.password, user.password)) {
+            return ResponseEntity.status(401).body(
+                mapOf("message" to "비밀번호가 올바르지 않습니다.")
+            )
+        }
+
+        val tokenInfo = jwtTokenProvider.createToken(user)
+        return ResponseEntity.ok(
+            mapOf(
+                "message" to "로그인 성공",
+                "accessToken" to tokenInfo.accessToken,
+                "refreshToken" to tokenInfo.refreshToken
+            )
+        )
     }
 
     fun userInfo(email: String): UserInfoResponse {
@@ -59,4 +76,16 @@ class UserService(
         )
     }
 
+    fun updateCountry(accessToken: String, contryDto: CountryDto): ResponseEntity<String> {
+        val claims = jwtTokenProvider.getClaims(accessToken, accessKey)
+        val email = claims["email"] as String
+
+        val user = userRepository.findByEmail(email)
+            ?: throw IllegalArgumentException("사용자를 찾을 수 없습니다.")
+
+        user.country = contryDto.contry
+        userRepository.save(user)
+
+        return ResponseEntity.status(HttpStatus.OK).body("회원가입이 완료되었습니다.")
+    }
 }


### PR DESCRIPTION
## 작업 내용

- Google OAuth를 사용한 로그인 기능을 구현했습니다.
- Google OAuth 인증 코드를 처리하고 사용자 정보를 가져오는 서비스를 추가했습니다.
- 사용자 정보를 저장하기 위해 데이터베이스 스키마에 새로운 필드를 추가했습니다.
- JWT 토큰 발급을 통해 인증된 사용자를 처리하는 로직을 구현했습니다.
- Google OAuth 로그인 후 국가 선택을 통해 회원가입을 완료하는 기능을 추가했습니다.

## 변경 사항

### POST /api/auth/google 엔드포인트 구현

#### Google OAuth 로그인

- **기능**: Google OAuth 인증 코드를 받아 토큰을 교환하고 사용자 정보를 처리
- **응답**:
  - **성공 시**:
    - Status: `200`
    - 반환 데이터: `accessToken`, `refreshToken`, `newUser` (신규 사용자 여부)
  - **실패 시**:
    - 메시지: `Google 토큰 요청 실패` 또는 `Google 인증 코드를 처리하는 중 오류 발생.`
    - Status: `500`

### POST /api/users/update-country 엔드포인트 구현

#### 국가 정보 업데이트 및 회원가입 완료

- **기능**: Google OAuth 로그인 후 사용자가 국가를 선택하여 회원가입을 완료
- **구현 세부사항**:
  - JWT `accessToken`을 통해 사용자 인증
  - 사용자의 `country` 필드를 업데이트하고 데이터베이스에 저장
- **응답**:
  - **성공 시**:
    - 메시지: `회원가입이 완료되었습니다.`
    - Status: `200`
  - **실패 시**:
    - 메시지: `사용자를 찾을 수 없습니다.`
    - Status: `400` (IllegalArgumentException 발생 시)

### 데이터베이스 스키마 업데이트

#### 새로운 필드 추가

- `name`: 사용자 이름 (Google 프로필의 `given_name`)
- `provider`: 인증 제공자 (예: `google`)
- `providerId`: Google OAuth 제공자 고유 ID (`sub`)

- **업데이트 결과**:
  - Google OAuth로 로그인한 신규 사용자는 데이터베이스에 저장되며, 기존 사용자는 이메일로 조회
  - 국가 선택 후 `country` 필드 업데이트로 회원가입 완료
  - 성공 시: JWT `accessToken`과 `refreshToken` 발급
  - 실패 시:
    - 메시지: `사용자 정보 처리 중 오류가 발생했습니다.`
    - Status: `500`

## 관련 이슈

- **#17**

