### PR TITLE
[Feature] #19 - Redis 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.projectlombok:lombok")
-	implementation("org.postgresql:postgresql:42.7.5")
+	implementation("com.mysql:mysql-connector-j")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testImplementation("org.springframework.security:spring-security-test")
@@ -45,6 +45,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-mail:3.1.5")
 	implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
 	implementation ("org.springframework.boot:spring-boot-starter-oauth2-client")
+	implementation ("org.springframework.boot:spring-boot-starter-data-redis")
 }
 
 kotlin {

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/JwtTokenProvider.kt
@@ -1,5 +1,6 @@
 package hs.kr.gbsw.doumi.auth.jwt
 
+import hs.kr.gbsw.doumi.auth.redis.service.RedisService
 import hs.kr.gbsw.doumi.auth.user.model.Users
 import io.jsonwebtoken.*
 import io.jsonwebtoken.io.Decoders
@@ -15,7 +16,9 @@ const val ACCESS_EXPIRATION_MILLISECONDS: Long = 1000 * 60 * 30
 const val REFRESH_EXPIRATION_MILLISECONDS: Long = 1000 * 60 * 60 * 24 * 14
 
 @Component
-class JwtTokenProvider {
+class JwtTokenProvider(
+    private val redisService: RedisService
+) {
 
     @Value("\${jwt.access_secret}")
     lateinit var access: String
@@ -50,7 +53,8 @@ class JwtTokenProvider {
             .signWith(refreshKey, Jwts.SIG.HS256)
             .compact()
 
-        return TokenInfo("Bearer", accessToken, refreshToken)
+        redisService.saveRefreshToken(user.email, refreshToken)
+        return TokenInfo("Bearer", accessToken)
     }
 
     fun validateToken(accessToken: String): Boolean {
@@ -59,40 +63,53 @@ class JwtTokenProvider {
             return true
         } catch (e: Exception) {
             when (e) {
-                is SecurityException -> {}
-                is MalformedJwtException -> {}
-                is ExpiredJwtException -> {}
-                is UnsupportedJwtException -> {}
-                is IllegalArgumentException -> {}
-                else -> {}
+                is SecurityException, is MalformedJwtException,
+                is ExpiredJwtException, is UnsupportedJwtException,
+                is IllegalArgumentException -> println(e.message)
             }
-            println(e.message)
+            return false
         }
-        return false
     }
 
-    fun validateRefreshToken(accessToken: String): Boolean {
+    fun validateExpiredAccessToken(accessToken: String, expectedEmail: String): Boolean {
         try {
-            getClaims(accessToken, refreshKey)
+            val claims = Jwts.parser()
+                .verifyWith(accessKey)
+                .build()
+                .parseSignedClaims(accessToken)
+                .payload
+            return claims.subject == expectedEmail
+        } catch (e: Exception) {
+            when (e) {
+                is SecurityException, is MalformedJwtException,
+                is UnsupportedJwtException, is IllegalArgumentException -> println(e.message)
+                is ExpiredJwtException -> {
+                    return e.claims.subject == expectedEmail
+                }
+            }
+            return false
+        }
+    }
+
+    fun validateRefreshToken(email: String): Boolean {
+        val refreshToken = redisService.getRefreshToken(email) ?: return false
+        try {
+            getClaims(refreshToken, refreshKey)
             return true
         } catch (e: Exception) {
             when (e) {
-                is SecurityException -> {}
-                is MalformedJwtException -> {}
-                is ExpiredJwtException -> {}
-                is UnsupportedJwtException -> {}
-                is IllegalArgumentException -> {}
-                else -> {}
+                is SecurityException, is MalformedJwtException,
+                is ExpiredJwtException, is UnsupportedJwtException,
+                is IllegalArgumentException -> println(e.message)
             }
-            println(e.message)
+            return false
         }
-        return false
     }
 
-    fun recreationAccessToken(refreshToken: String): String? {
+    fun recreationAccessToken(email: String): String? {
+        val refreshToken = redisService.getRefreshToken(email) ?: return null
         try {
             val claims = getClaims(refreshToken, refreshKey)
-            val email = claims.subject
             val userId = claims["userId"] as Long
             val auth = claims["auth"] as String
 
@@ -114,8 +131,8 @@ class JwtTokenProvider {
         }
     }
 
-    fun getAuthentication(newAccessToken: String): UsernamePasswordAuthenticationToken? {
-        val claims = getClaims(newAccessToken, accessKey)
+    fun getAuthentication(accessToken: String): UsernamePasswordAuthenticationToken? {
+        val claims = getClaims(accessToken, accessKey)
         val email = claims.subject
         val auth = claims["auth"] as String
         val authorities = auth.split(",").map { SimpleGrantedAuthority(it.trim()) }
@@ -123,12 +140,10 @@ class JwtTokenProvider {
         return UsernamePasswordAuthenticationToken(principal, "", authorities)
     }
 
-
-    fun getClaims(accessToken: String, key: SecretKey): Claims =
+    fun getClaims(token: String, key: SecretKey): Claims =
         Jwts.parser()
             .verifyWith(key)
             .build()
-            .parseSignedClaims(accessToken)
+            .parseSignedClaims(token)
             .payload
-
 }

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/TokenInfo.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/TokenInfo.kt
@@ -3,5 +3,4 @@ package hs.kr.gbsw.doumi.auth.jwt
 data class TokenInfo(
     val grantType: String,
     val accessToken: String,
-    val refreshToken: String,
 )

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/oauth/service/GoogleOAuthService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/oauth/service/GoogleOAuthService.kt
@@ -1,5 +1,6 @@
 package hs.kr.gbsw.doumi.auth.oauth.service
 
+import hs.kr.gbsw.doumi.auth.jwt.ACCESS_EXPIRATION_MILLISECONDS
 import hs.kr.gbsw.doumi.auth.jwt.JwtTokenProvider
 import hs.kr.gbsw.doumi.auth.user.model.Users
 import hs.kr.gbsw.doumi.auth.user.repository.UserRepository
@@ -60,7 +61,7 @@ class GoogleOAuthService(
             } else {
                 throw RuntimeException("Google 토큰 요청 실패")
             }
-        } catch (ex: Exception) {
+        } catch (_: Exception) {
             throw RuntimeException("Google 인증 코드를 처리하는 중 오류 발생")
         }
     }
@@ -91,14 +92,24 @@ class GoogleOAuthService(
 
         val tokenInfo = jwtTokenProvider.createToken(user)
 
-        return ResponseEntity(
-            mapOf(
-                "accessToken" to tokenInfo.accessToken,
-                "refreshToken" to tokenInfo.refreshToken,
+        val cookie = ResponseCookie.from("access_token", tokenInfo.accessToken)
+            .httpOnly(true)
+            .secure(false) //현재는 개발을 위해 Https off
+            .path("/")
+            .maxAge(ACCESS_EXPIRATION_MILLISECONDS / 1000)
+            .sameSite("Lax")
+            .build()
+
+        val headers = HttpHeaders().apply {
+            add(HttpHeaders.SET_COOKIE, cookie.toString())
+        }
+
+        return ResponseEntity.ok()
+            .headers(headers)
+            .body(mapOf(
+                "message" to "토큰 갱신 성공",
                 "newUser" to (user.country == null)
-            ),
-            HttpStatus.OK
-        )
+            ))
     }
 
     private fun fetchGoogleUserInfo(accessToken: String): Map<String, Any> {

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/redis/config/RedisConfig.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/redis/config/RedisConfig.kt
@@ -1,0 +1,21 @@
+package hs.kr.gbsw.doumi.auth.redis.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+
+@Configuration
+class RedisConfig {
+    @Bean
+    fun redisTemplate(connectionFactory: RedisConnectionFactory?): RedisTemplate<String?, Any?> {
+        val template = RedisTemplate<String?, Any?>()
+        template.connectionFactory = connectionFactory
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = Jackson2JsonRedisSerializer(Any::class.java)
+        return template
+    }
+}

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/redis/service/RedisService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/redis/service/RedisService.kt
@@ -1,0 +1,33 @@
+package hs.kr.gbsw.doumi.auth.redis.service
+
+import hs.kr.gbsw.doumi.auth.jwt.REFRESH_EXPIRATION_MILLISECONDS
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
+
+
+
+
+@Service
+class RedisService(private val redisTemplate: RedisTemplate<String, Any>) {
+    @Value("\${jwt.refresh_secret}")
+    lateinit var refresh: String
+
+    fun saveRefreshToken(username: String, refreshToken: String) {
+        redisTemplate.opsForValue().set(
+            refresh + username,
+            refreshToken,
+            REFRESH_EXPIRATION_MILLISECONDS,
+            TimeUnit.SECONDS
+        )
+    }
+
+    fun getRefreshToken(username: String?): String? {
+        return redisTemplate.opsForValue().get(refresh + username) as String?
+    }
+
+    fun deleteRefreshToken(username: String?) {
+        redisTemplate.delete(refresh + username)
+    }
+}

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/controller/UserController.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/controller/UserController.kt
@@ -9,7 +9,6 @@ import hs.kr.gbsw.doumi.auth.user.service.UserService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
 
@@ -20,17 +19,22 @@ class UserController(
 ) {
 
     @PostMapping
-    fun signup(@Valid @RequestBody dto: UserSignupRequest): ResponseEntity<String> {
+    fun signup(
+        @Valid @RequestBody dto: UserSignupRequest
+    ): ResponseEntity<String> {
         return userService.signup(dto)
     }
 
     @PostMapping("/login")
-    fun login(@RequestBody @Valid dto: UserLoginRequest): ResponseEntity<Map<String, String>> {
+    fun login(
+        @RequestBody @Valid dto: UserLoginRequest,
+    ): ResponseEntity<Map<String, String>> {
         return userService.login(dto)
     }
 
     @GetMapping("/info")
-    fun userInfo(authentication: Authentication): ResponseEntity<UserInfoResponse> {
+    fun userInfo(
+    ): ResponseEntity<UserInfoResponse> {
         val email = (SecurityContextHolder.getContext().authentication.principal as CustomUser).username
         val user = userService.userInfo(email)
         return ResponseEntity(user, HttpStatus.OK)
@@ -46,4 +50,23 @@ class UserController(
         return ResponseEntity.ok(userService.updateCountry(accessToken, countryDto))
     }
 
+    @PostMapping("/refresh")
+    fun refreshToken(
+        @RequestParam email: String,
+        @RequestHeader("Authorization") authHeader: String?
+    ): ResponseEntity<Map<String, String>> {
+        val accessToken = authHeader?.let {
+            if (it.startsWith("Bearer ")) it.substring(7) else null
+        } ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(mapOf("message" to "액세스 토큰이 필요합니다."))
+
+        return userService.refreshToken(email, accessToken)
+    }
+
+    @PostMapping("/logout")
+    fun logout(
+        @RequestParam email: String
+    ): ResponseEntity<String> {
+        return userService.logout(email)
+    }
 }

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/service/UserService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/service/UserService.kt
@@ -1,7 +1,9 @@
 package hs.kr.gbsw.doumi.auth.user.service
 
 import hs.kr.gbsw.doumi.auth.email.service.EmailService
+import hs.kr.gbsw.doumi.auth.jwt.ACCESS_EXPIRATION_MILLISECONDS
 import hs.kr.gbsw.doumi.auth.jwt.JwtTokenProvider
+import hs.kr.gbsw.doumi.auth.redis.service.RedisService
 import hs.kr.gbsw.doumi.auth.user.dto.CountryDto
 import hs.kr.gbsw.doumi.auth.user.dto.UserInfoResponse
 import hs.kr.gbsw.doumi.auth.user.dto.UserLoginRequest
@@ -10,7 +12,9 @@ import hs.kr.gbsw.doumi.auth.user.repository.UserRepository
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
@@ -20,7 +24,8 @@ class UserService(
     private val userRepository: UserRepository,
     private val passwordEncoder: PasswordEncoder,
     private val jwtTokenProvider: JwtTokenProvider,
-    private val emailService: EmailService
+    private val emailService: EmailService,
+    private val redisService: RedisService
 ) {
     @Value("\${jwt.access_secret}")
     lateinit var access: String
@@ -56,13 +61,22 @@ class UserService(
         }
 
         val tokenInfo = jwtTokenProvider.createToken(user)
-        return ResponseEntity.ok(
-            mapOf(
-                "message" to "로그인 성공",
-                "accessToken" to tokenInfo.accessToken,
-                "refreshToken" to tokenInfo.refreshToken
-            )
-        )
+
+        val cookie = ResponseCookie.from("access_token", tokenInfo.accessToken)
+            .httpOnly(true)
+            .secure(false) //현재는 개발을 위해 Https off
+            .path("/")
+            .maxAge(ACCESS_EXPIRATION_MILLISECONDS / 1000)
+            .sameSite("Lax")
+            .build()
+
+        val headers = HttpHeaders().apply {
+            add(HttpHeaders.SET_COOKIE, cookie.toString())
+        }
+
+        return ResponseEntity.ok()
+            .headers(headers)
+            .body(mapOf("message" to "로그인 성공"))
     }
 
     fun userInfo(email: String): UserInfoResponse {
@@ -81,11 +95,49 @@ class UserService(
         val email = claims["email"] as String
 
         val user = userRepository.findByEmail(email)
-            ?: throw IllegalArgumentException("사용자를 찾을 수 없습니다.")
+            ?: return ResponseEntity.status(404).body("사용자를 찾을 수 없습니다.")
 
         user.country = contryDto.contry
         userRepository.save(user)
 
-        return ResponseEntity.status(HttpStatus.OK).body("회원가입이 완료되었습니다.")
+        return ResponseEntity.status(HttpStatus.OK).body("회원 정보가 업데이트되었습니다.")
+    }
+
+    fun refreshToken(email: String, accessToken: String): ResponseEntity<Map<String, String>> {
+        if (!jwtTokenProvider.validateExpiredAccessToken(accessToken, email)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(mapOf("message" to "유효하지 않은 액세스 토큰입니다."))
+        }
+
+        if (!jwtTokenProvider.validateRefreshToken(email)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(mapOf("message" to "유효하지 않은 리프레시 토큰입니다."))
+        }
+
+        val newAccessToken = jwtTokenProvider.recreationAccessToken(email)
+            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(mapOf("message" to "액세스 토큰 재발급에 실패했습니다."))
+
+        val cookie = ResponseCookie.from("doumi_access_token", newAccessToken)
+            .httpOnly(true)
+            .secure(false) //현재는 개발을 위해 Https off
+            .path("/")
+            .maxAge(ACCESS_EXPIRATION_MILLISECONDS / 1000)
+            .sameSite("Lax")
+            .build()
+
+        val headers = HttpHeaders().apply {
+            add(HttpHeaders.SET_COOKIE, cookie.toString())
+        }
+
+        return ResponseEntity.ok()
+            .headers(headers)
+            .body(mapOf("message" to "토큰 갱신 성공"))
+    }
+
+    fun logout(email: String): ResponseEntity<String> {
+        redisService.deleteRefreshToken(email)
+
+        return ResponseEntity.ok("로그아웃 성공")
     }
 }


### PR DESCRIPTION
## 작업 내용

- Redis를 추가하여 리프레시 토큰을 저장하도록 구현했습니다.
- 엑세스 토큰을 HTTP 헤더의 쿠키에 담아 프론트로 전송하도록 수정했습니다.

## 변경 사항

### 로그인 로직 수정

- **기존 방식**:
  - 로그인 시 `accessToken`과 `refreshToken`을 JWT 평문으로 프론트에 전송
- **변경 후 방식**:
  - `refreshToken`을 Redis에 저장하고, 필요 시 쿠키에 담긴 `accessToken`에서 이메일을 추출하여 새로운 `accessToken` 발급
  - `accessToken`을 HTTP 헤더의 `Set-Cookie`를 통해 쿠키로 프론트에 전송

### Redis 통합

- **기능**: 리프레시 토큰을 Redis에 저장하여 관리
- **구현 세부사항**:
  - 로그인 시 발급된 `refreshToken`을 Redis에 저장
  - Redis를 통해 토큰의 유효성 및 만료 관리

### 엑세스 토큰 쿠키 처리

- **기능**: 엑세스 토큰을 쿠키로 전송
- **구현 세부사항**:
  - `accessToken`을 `Set-Cookie` 헤더에 포함하여 프론트로 전송
  - 쿠키 속성: `HttpOnly`, `Secure` 옵션 적용 (환경에 따라 조정 가능)

## 주의 사항

- 현재 `accessToken`은 HTTP 헤더의 쿠키로 전송되며, HTTPS 미적용 시 보안 취약점이 존재할 수 있습니다.
- 추후 HTTPS 헤더를 사용하여 보안성을 강화할 예정입니다.

## 관련 이슈

- **#19**