### PR TITLE
[Hotfix] #30 - 코드 리팩토링

### DIFF
--- a/src/main/kotlin/hs/kr/gbsw/doumi/SecurityConfig.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/SecurityConfig.kt
@@ -25,7 +25,16 @@ class SecurityConfig(
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {
-                it.requestMatchers("/api/users", "/api/users/login").permitAll()
+                it.requestMatchers(
+                    "/api/users",
+                    "/api/users/login",
+                    "/api/users/verify",
+                    "/api/users/refresh",
+                    "/api/email/send",
+                    "/api/board/posts",
+                    "/api/board/posts/**",
+                    "/api/map"
+                ).permitAll()
                     .requestMatchers("/api/users/info").authenticated()
                     .anyRequest().permitAll()
             }

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/JwtAuthenticationFilter.kt
@@ -49,7 +49,7 @@ class JwtAuthenticationFilter(
     private fun resolveToken(request: HttpServletRequest): String? {
         val bearerToken = request.getHeader("Authorization")
 
-        return if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+        return if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             bearerToken.substring(7)
         } else {
             null

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/oauth/service/GoogleOAuthService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/oauth/service/GoogleOAuthService.kt
@@ -83,7 +83,6 @@ class GoogleOAuthService(
                     email = email,
                     name = name,
                     password = null,
-                    phone = null,
                     country = null,
                     createdAt = LocalDateTime.now(),
                     provider = provider,

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/redis/service/RedisService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/redis/service/RedisService.kt
@@ -32,7 +32,7 @@ class RedisService(private val redisTemplate: RedisTemplate<String, Any>) {
         redisTemplate.opsForValue().set(
             "verify:email:$email",
             "verified",
-            900L, // 15분
+            600L, // 10분
             TimeUnit.SECONDS
         )
     }

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/controller/UserController.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/controller/UserController.kt
@@ -1,14 +1,10 @@
 package hs.kr.gbsw.doumi.auth.user.controller
 
-import hs.kr.gbsw.doumi.auth.jwt.dto.CustomUser
 import hs.kr.gbsw.doumi.auth.user.dto.*
-import hs.kr.gbsw.doumi.auth.user.model.Users
 import hs.kr.gbsw.doumi.auth.user.service.UserService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
 import java.security.Principal
 
@@ -40,9 +36,7 @@ class UserController(
     }
 
     @GetMapping("/info")
-    fun userInfo(
-        @AuthenticationPrincipal principal: Principal
-    ): ResponseEntity<UserInfoResponse> {
+    fun userInfo(principal: Principal): ResponseEntity<UserInfoResponse> {
         val email = principal.name
         val user = userService.userInfo(email)
         return ResponseEntity(user, HttpStatus.OK)
@@ -50,7 +44,7 @@ class UserController(
 
     @PutMapping("/info")
     fun updateUserInfo(
-        @AuthenticationPrincipal principal: Principal,
+        principal: Principal,
         @RequestBody dto: UserInfoRequest
     ): ResponseEntity<UserInfoResponse> {
         val email = principal.name
@@ -60,7 +54,7 @@ class UserController(
 
     @PutMapping("/info/password")
     fun updateUserPassword(
-        @AuthenticationPrincipal principal: Principal,
+        principal: Principal,
         @RequestBody password: String
     ): ResponseEntity<UserInfoResponse> {
         val email = principal.name

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/dto/UserDto.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/dto/UserDto.kt
@@ -58,13 +58,12 @@ data class UserLoginRequest(
 data class UserInfoResponse(
     val email: String,
     val name: String?,
-    val country: Country,
+    val country: Int?,
     val createdAt: LocalDateTime,
     val provider: String?,
 )
 
 data class UserInfoRequest(
-    val email: String,
     val name: String?,
-    val country: Country,
+    val countryId: Int,
 )

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/model/Users.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/model/Users.kt
@@ -19,7 +19,7 @@ class Users(
     @Column(nullable = true)
     var password: String?,
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "country_id")
     var country: Country?,
 

--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/service/UserService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/user/service/UserService.kt
@@ -96,7 +96,7 @@ class UserService(
         return UserInfoResponse(
             user.email,
             user.name,
-            user.country!!,
+            user.country!!.id,
             user.createdAt,
             user.provider
         )
@@ -108,14 +108,17 @@ class UserService(
         if (user.name != dto.name) {
             user.name = dto.name!!
         }
-        if (user.country != dto.country) {
-            user.country = dto.country
+        if (user.country!!.id != dto.countryId) {
+            val country = countryRepository.findById(dto.countryId).get()
+            user.country = country
         }
+
+        userRepository.save(user)
 
         return UserInfoResponse(
             user.email,
             user.name,
-            user.country!!,
+            user.country!!.id,
             user.createdAt,
             user.provider
         )
@@ -128,10 +131,12 @@ class UserService(
             user.password = passwordEncoder.encode(password)
         }
 
+        userRepository.save(user)
+
         return UserInfoResponse(
             user.email,
             user.name,
-            user.country!!,
+            user.country!!.id,
             user.createdAt,
             user.provider
         )

--- a/src/main/kotlin/hs/kr/gbsw/doumi/board/controller/BoardController.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/board/controller/BoardController.kt
@@ -10,12 +10,11 @@ import hs.kr.gbsw.doumi.board.service.BoardService
 import org.springframework.data.domain.Page
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import java.security.Principal
 import java.time.LocalDate
 
-@RequestMapping("/board")
+@RequestMapping("/api/board")
 @RestController
 class BoardController(
     val boardService: BoardService,
@@ -31,23 +30,34 @@ class BoardController(
         return ResponseEntity("${ex.message}", HttpStatus.UNAUTHORIZED)
     }
 
-    @PostMapping
+    @PostMapping("/post")
     fun createPost(
-        @AuthenticationPrincipal principal: Principal,
+        principal: Principal,
         @RequestBody dto: CreatePostDto
-    ): ResponseEntity<Post> {
+    ): ResponseEntity<ResponsePostDto> {
         val result = boardService.createPost(dto, principal.name)
-        return ResponseEntity(result, HttpStatus.CREATED)
+        val response = ResponsePostDto(
+            result.id!!,
+            result.title,
+            result.body,
+            0,
+            false,
+            0,
+            result.createdAt,
+            result.updatedAt,
+            result.isWritten
+        )
+        return ResponseEntity(response, HttpStatus.CREATED)
     }
 
-    @GetMapping
+    @GetMapping("/posts")
     fun countryList(
     ): ResponseEntity<List<Country>> {
         val result = boardService.getCountries()
         return ResponseEntity(result, HttpStatus.OK)
     }
 
-    @GetMapping("/{countryId}")
+    @GetMapping("/posts/{countryId}")
     fun getListByCountry(
         @PathVariable(required = true) countryId: Int,
         @RequestParam(value = "page", defaultValue = "0") page: Int,
@@ -57,20 +67,22 @@ class BoardController(
         return ResponseEntity(result, HttpStatus.OK)
     }
 
-    @GetMapping("/{postId}")
+    @GetMapping("/post/{postId}")
     fun getPost(
-        @AuthenticationPrincipal principal: Principal,
+        principal: Principal,
         @PathVariable(required = true) postId: Long
     ): ResponseEntity<ResponsePostDto> {
         val result = boardService.getPost(postId)
         val like = boardService.getLike(postId)
         val isLike = boardService.getIsLike(principal.name, postId)
+        val view = boardService.addView(postId)
         val response = ResponsePostDto(
+            result.id!!,
             result.title,
             result.body,
             like,
             isLike,
-            result.view,
+            view,
             result.createdAt,
             result.updatedAt,
             result.isWritten,
@@ -78,47 +90,59 @@ class BoardController(
         return ResponseEntity(response, HttpStatus.OK)
      }
 
-    @PutMapping("/{postId}")
+    @PutMapping("/post/{postId}")
     fun modifyPost(
-        @AuthenticationPrincipal principal: Principal,
+        principal: Principal,
         @PathVariable(required = true) postId: Long,
         @RequestBody dto: CreatePostDto
-    ): ResponseEntity<Post> {
+    ): ResponseEntity<ResponsePostDto> {
         val result = boardService.modifyPost(principal.name, postId, dto)
-        return if (result.second) ResponseEntity(result.first, HttpStatus.OK) else ResponseEntity(result.first, HttpStatus.NOT_MODIFIED)
+        val response = ResponsePostDto(
+            result.first.id!!,
+            result.first.title,
+            result.first.body,
+            boardService.getLike(postId),
+
+            boardService.getIsLike(principal.name, postId),
+            result.first.view,
+            result.first.createdAt,
+            result.first.updatedAt,
+            result.first.isWritten
+        )
+        return if (result.second) ResponseEntity(response, HttpStatus.OK) else ResponseEntity(response, HttpStatus.BAD_REQUEST)
     }
 
-    @DeleteMapping("/{postId}")
+    @DeleteMapping("/post/{postId}")
     fun deletePost(
-        @AuthenticationPrincipal principal: Principal,
+        principal: Principal,
         @PathVariable postId: Long
     ): ResponseEntity<Void> {
         boardService.deletePost(principal.name, postId)
         return ResponseEntity(HttpStatus.NO_CONTENT)
     }
 
-    @PostMapping("/{postId}/like")
+    @PostMapping("/post/{postId}/like")
     fun postLike(
-        @AuthenticationPrincipal principal: Principal,
+        principal: Principal,
         @PathVariable(required = true) postId: Long
     ): ResponseEntity<Like> {
         val result = boardService.postLike(principal.name, postId)
         return ResponseEntity(result, HttpStatus.CREATED)
     }
 
-    @DeleteMapping("/{postId}/like")
+    @DeleteMapping("/post/{postId}/like")
     fun deleteLike(
-        @AuthenticationPrincipal principal: Principal,
+        principal: Principal,
         @PathVariable(required = true) postId: Long
     ): ResponseEntity<Void> {
         boardService.deleteLike(email = principal.name, postId)
         return ResponseEntity(HttpStatus.NO_CONTENT)
     }
 
-    @GetMapping("/event")
-    fun event(): ResponseEntity<EventResponseDto> {
-        val response = boardService.eventList(LocalDate.now().toString())
-        return ResponseEntity(response, HttpStatus.OK)
-    }
+//    @GetMapping("/event")
+//    fun event(): ResponseEntity<EventResponseDto> {
+//        val response = boardService.eventList(LocalDate.now().toString())
+//        return ResponseEntity(response, HttpStatus.OK)
+//    }
 
 }

--- a/src/main/kotlin/hs/kr/gbsw/doumi/board/controller/CommentController.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/board/controller/CommentController.kt
@@ -2,7 +2,6 @@ package hs.kr.gbsw.doumi.board.controller
 
 import hs.kr.gbsw.doumi.board.dto.CreateCommentDto
 import hs.kr.gbsw.doumi.board.dto.ResponseCommentDto
-import hs.kr.gbsw.doumi.board.dto.UpdateCommentDto
 import hs.kr.gbsw.doumi.board.model.Comment
 import hs.kr.gbsw.doumi.board.service.CommentService
 import org.springframework.http.HttpStatus
@@ -10,8 +9,9 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import java.security.Principal
+import java.time.LocalDateTime
 
-@RequestMapping("/comment")
+@RequestMapping("/api/comment")
 @RestController
 class CommentController(
     val commentService: CommentService,
@@ -29,12 +29,19 @@ class CommentController(
 
     @PostMapping("/{postId}")
     fun createComment(
-        @AuthenticationPrincipal principal: Principal,
+        principal: Principal,
         @PathVariable postId: Long,
         @RequestBody dto: CreateCommentDto
-    ): ResponseEntity<Comment> {
+    ): ResponseEntity<ResponseCommentDto> {
         val result = commentService.create(dto, principal.name, postId)
-        return ResponseEntity(result, HttpStatus.CREATED)
+        val response = ResponseCommentDto(
+            id = result.id!!,
+            body = result.body,
+            createdAt = result.createdAt,
+            updatedAt = result.createdAt,
+            isWritten = result.isWritten,
+        )
+        return ResponseEntity(response, HttpStatus.CREATED)
     }
 
     @GetMapping("/{postId}")
@@ -47,18 +54,25 @@ class CommentController(
 
     @PutMapping("/{postId}/{commentId}")
     fun modifyComment(
-        @AuthenticationPrincipal principal: Principal,
+        principal: Principal,
         @PathVariable postId: Long,
         @PathVariable commentId: Long,
-        @RequestBody dto: UpdateCommentDto
-    ): ResponseEntity<Comment> {
+        @RequestBody dto: CreateCommentDto
+    ): ResponseEntity<ResponseCommentDto> {
         val result = commentService.updateComment(commentId, dto, principal.name)
-        return ResponseEntity(result, HttpStatus.OK)
+        val response = ResponseCommentDto(
+            id = result.first.id!!,
+            body = result.first.body,
+            createdAt = result.first.createdAt,
+            updatedAt = result.first.createdAt,
+            isWritten = result.first.isWritten,
+        )
+        return if (result.second) ResponseEntity(response, HttpStatus.OK) else ResponseEntity(response, HttpStatus.BAD_REQUEST)
     }
 
     @DeleteMapping("/{postId}/{commentId}")
     fun deleteComment(
-        @AuthenticationPrincipal principal: Principal,
+        principal: Principal,
         @PathVariable postId: Long,
         @PathVariable commentId: Long,
         ): ResponseEntity<Void> {

--- a/src/main/kotlin/hs/kr/gbsw/doumi/board/dto/BoardDto.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/board/dto/BoardDto.kt
@@ -23,6 +23,7 @@ data class CreatePostDto(
 }
 
 data class ResponsePostDto(
+    val id: Long,
     val title: String,
     val body: String,
     val like: Int,

--- a/src/main/kotlin/hs/kr/gbsw/doumi/board/dto/CommentDto.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/board/dto/CommentDto.kt
@@ -6,13 +6,10 @@ data class CreateCommentDto(
     val body: String,
 )
 
-data class UpdateCommentDto(
-    val body: String
-)
-
 data class ResponseCommentDto(
     val id: Long,
     val body: String,
+    val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
     val isWritten: Boolean,
 )

--- a/src/main/kotlin/hs/kr/gbsw/doumi/board/model/Board.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/board/model/Board.kt
@@ -3,6 +3,7 @@ package hs.kr.gbsw.doumi.board.model
 import hs.kr.gbsw.doumi.auth.user.model.Country
 import hs.kr.gbsw.doumi.auth.user.model.Users
 import jakarta.persistence.*
+import net.minidev.json.annotate.JsonIgnore
 import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
 
@@ -22,10 +23,12 @@ class Post(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @JsonIgnore
     val user: Users,
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "country_id")
+    @JsonIgnore
     var country: Country,
 
     @CreationTimestamp

--- a/src/main/kotlin/hs/kr/gbsw/doumi/board/model/Comment.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/board/model/Comment.kt
@@ -2,6 +2,7 @@ package hs.kr.gbsw.doumi.board.model
 
 import hs.kr.gbsw.doumi.auth.user.model.Users
 import jakarta.persistence.*
+import net.minidev.json.annotate.JsonIgnore
 import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
 
@@ -16,10 +17,12 @@ class Comment(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @JsonIgnore
     val user: Users,
 
     @ManyToOne
     @JoinColumn(name = "post_id")
+    @JsonIgnore
     val post: Post,
 
     @CreationTimestamp

--- a/src/main/kotlin/hs/kr/gbsw/doumi/board/model/Like.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/board/model/Like.kt
@@ -4,6 +4,7 @@ import hs.kr.gbsw.doumi.auth.user.model.Users
 import jakarta.persistence.*
 
 @Entity
+@Table(name = "post_like")
 data class Like(
 
     @Id

--- a/src/main/kotlin/hs/kr/gbsw/doumi/board/service/BoardService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/board/service/BoardService.kt
@@ -10,6 +10,7 @@ import hs.kr.gbsw.doumi.auth.user.repository.UserRepository
 import hs.kr.gbsw.doumi.board.dto.CreatePostDto
 import hs.kr.gbsw.doumi.board.dto.EventItem
 import hs.kr.gbsw.doumi.board.dto.EventResponseDto
+import hs.kr.gbsw.doumi.board.dto.ResponsePostDto
 import hs.kr.gbsw.doumi.board.model.Like
 import hs.kr.gbsw.doumi.board.model.Post
 import hs.kr.gbsw.doumi.board.repository.BoardRepository
@@ -38,54 +39,54 @@ class BoardService(
     val likeRepository: LikeRepository,
 ) {
 
-    @Value("\${board.event.url}")
-    lateinit var eventInfoApi: String
+//    @Value("\${board.event.url}")
+//    lateinit var eventInfoApi: String
 
-    @Value("\${board.event.encode}")
-    lateinit var key: String
+//    @Value("\${board.event.encode}")
+//    lateinit var key: String
 
-    fun eventList(date: String): EventResponseDto {
-        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-        val now = LocalDate.parse(date, formatter)
-
-        val urlStr = "$eventInfoApi?serviceKey=$key&type=json"
-        val objectMapper = jacksonObjectMapper()
-        val allEvents = mutableListOf<EventItem>()
-
-        val initUrl = URL("$urlStr&pageNo=1&numOfRows=1")
-        val initConn = initUrl.openConnection() as HttpURLConnection
-        initConn.requestMethod = "GET"
-        initConn.setRequestProperty("Accept", "application/json")
-        val initResponse = initConn.inputStream.bufferedReader().use { it.readText() }
-
-        val initJson = objectMapper.readTree(initResponse)
-        val total = initJson.path("response").path("body").path("totalCount").intValue()
-        val totalPages = Math.ceil(total / 100.0).toInt()
-
-        for (i in 1..totalPages) {
-            val pageUrl = URL("$urlStr&pageNo=$i&numOfRows=100")
-            val conn = pageUrl.openConnection() as HttpURLConnection
-            conn.requestMethod = "GET"
-            conn.setRequestProperty("Accept", "application/json")
-            val response = conn.inputStream.bufferedReader().use { it.readText() }
-
-            val jsonNode = objectMapper.readTree(response)
-            val itemsNode = jsonNode.path("response").path("body").path("items").path("item")
-
-            val events = when {
-                itemsNode.isArray -> objectMapper.convertValue(itemsNode, object : TypeReference<List<EventItem>>() {})
-                itemsNode.isObject -> listOf(objectMapper.convertValue(itemsNode, EventItem::class.java))
-                else -> emptyList()
-            }
-
-            events.filterTo(allEvents) { event ->
-                val endDate = LocalDate.parse(event.eventEndDate, formatter)
-                !endDate.isBefore(now)
-            }
-        }
-
-        return EventResponseDto(allEvents)
-    }
+//    fun eventList(date: String): EventResponseDto {
+//        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+//        val now = LocalDate.parse(date, formatter)
+//
+//        val urlStr = "$eventInfoApi?serviceKey=$key&type=json"
+//        val objectMapper = jacksonObjectMapper()
+//        val allEvents = mutableListOf<EventItem>()
+//
+//        val initUrl = URL("$urlStr&pageNo=1&numOfRows=1")
+//        val initConn = initUrl.openConnection() as HttpURLConnection
+//        initConn.requestMethod = "GET"
+//        initConn.setRequestProperty("Accept", "application/json")
+//        val initResponse = initConn.inputStream.bufferedReader().use { it.readText() }
+//
+//        val initJson = objectMapper.readTree(initResponse)
+//        val total = initJson.path("response").path("body").path("totalCount").intValue()
+//        val totalPages = Math.ceil(total / 100.0).toInt()
+//
+//        for (i in 1..totalPages) {
+//            val pageUrl = URL("$urlStr&pageNo=$i&numOfRows=100")
+//            val conn = pageUrl.openConnection() as HttpURLConnection
+//            conn.requestMethod = "GET"
+//            conn.setRequestProperty("Accept", "application/json")
+//            val response = conn.inputStream.bufferedReader().use { it.readText() }
+//
+//            val jsonNode = objectMapper.readTree(response)
+//            val itemsNode = jsonNode.path("response").path("body").path("items").path("item")
+//
+//            val events = when {
+//                itemsNode.isArray -> objectMapper.convertValue(itemsNode, object : TypeReference<List<EventItem>>() {})
+//                itemsNode.isObject -> listOf(objectMapper.convertValue(itemsNode, EventItem::class.java))
+//                else -> emptyList()
+//            }
+//
+//            events.filterTo(allEvents) { event ->
+//                val endDate = LocalDate.parse(event.eventEndDate, formatter)
+//                !endDate.isBefore(now)
+//            }
+//        }
+//
+//        return EventResponseDto(allEvents)
+//    }
 
     fun createPost(dto: CreatePostDto, email: String): Post {
         val user = userRepository.findByEmail(email)!!
@@ -125,6 +126,13 @@ class BoardService(
         return likeRepository.existsByUserEmailAndId(email, postId)
     }
 
+    fun addView(postId: Long): Int {
+        val post = boardRepository.findById(postId).get()
+        post.view += 1
+        boardRepository.save(post)
+        return post.view
+    }
+
     fun modifyPost(
         email: String,
         id: Long,
@@ -137,14 +145,17 @@ class BoardService(
         var modified = false
         if (post.title != dto.title) {
             post.title = dto.title
+            post.isWritten = true
             modified = true
         }
         if (post.body != dto.body) {
             post.body = dto.body
+            post.isWritten = true
             modified = true
         }
         if (post.country.id != dto.country) {
             post.country = countryRepository.findById(dto.country).get()
+            post.isWritten = true
             modified = true
         }
 

--- a/src/main/kotlin/hs/kr/gbsw/doumi/board/service/CommentService.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/board/service/CommentService.kt
@@ -3,7 +3,6 @@ package hs.kr.gbsw.doumi.board.service
 import hs.kr.gbsw.doumi.board.dto.CreateCommentDto
 import hs.kr.gbsw.doumi.auth.user.repository.UserRepository
 import hs.kr.gbsw.doumi.board.dto.ResponseCommentDto
-import hs.kr.gbsw.doumi.board.dto.UpdateCommentDto
 import hs.kr.gbsw.doumi.board.model.Comment
 import hs.kr.gbsw.doumi.board.repository.CommentRepository
 import org.springframework.stereotype.Service
@@ -35,7 +34,8 @@ class CommentService(
             ResponseCommentDto(
                 id = comment.id!!,
                 body = comment.body,
-                updatedAt = LocalDateTime.now(),
+                createdAt = comment.createdAt,
+                updatedAt = comment.updatedAt,
                 isWritten = comment.isWritten,
             )
         }
@@ -47,17 +47,25 @@ class CommentService(
 
     fun updateComment(
         commentId: Long,
-        dto: UpdateCommentDto,
+        dto: CreateCommentDto,
         email: String
-    ): Comment {
+    ): Pair<Comment, Boolean> {
         val comment = getComment(commentId)
 
         if (comment.user.email != email) {
             throw IllegalAccessException("Can only modify own comment.")
         }
 
-        comment.body = dto.body
-        return commentRepository.save(comment)
+        var modified = false;
+
+        if (comment.body != dto.body) {
+            comment.body = dto.body
+            comment.updatedAt = LocalDateTime.now()
+            comment.isWritten = true
+            modified = true
+        }
+
+        return if (modified) Pair(commentRepository.save(comment), modified) else Pair(comment, modified)
     }
 
     fun deleteComment(commentId: Long, email: String) {


### PR DESCRIPTION
- 직렬화 오류의 발생을 막기 위해 JsonIgnore 추가
- 잘못된 RequestMapping 수정
- Board와 Comment의 생성 시에 ResponseDto로 반환
- BoardResponseDto에 id 포함
- event 주석 처리
- 게시글 열람 시에 조회수 추가
- isWritten 사용
- ResponseCommentDto에 createdAt을 함께 반환
- like 엔티티의 테이블명 변경(예약어)
- permitAll에 user 관련, 게시판 관련, 지도 관련 엔드포인트 추가
- @AuthenticationPrincipal 삭제