### PR TITLE
[Hotfix] #30 - 액세스 키 재발급 수정

### DIFF
--- a/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/hs/kr/gbsw/doumi/auth/jwt/JwtTokenProvider.kt
@@ -110,8 +110,8 @@ class JwtTokenProvider(
         val refreshToken = redisService.getRefreshToken(email) ?: return null
         try {
             val claims = getClaims(refreshToken, refreshKey)
-            val userId = claims["userId"] as Long
-            val auth = claims["auth"] as String
+            val userId = (claims["userId"] as Number).toLong()
+            val auth = (claims["auth"] as? String) ?: "default"
 
             val now = Date()
             val accessExpiration = Date(now.time + ACCESS_EXPIRATION_MILLISECONDS)


### PR DESCRIPTION
## 변경 사항
- Refresh 키에는 auth 항목이 없으나 auth 항목을 가져오는 것을 엘비스 연산자로 auth가 null일때 default를 넣도록 하여 해결
- userId는 Long이나 jwt에서 파싱할 때는 Int로 취급되기 때문에 Number로 받아 toLong()을 통해 형변환.
## 관련 이슈
- #30 